### PR TITLE
Fixed dependency in iosevka-generate to make the repository tappable again

### DIFF
--- a/iosevka-generate.rb
+++ b/iosevka-generate.rb
@@ -6,7 +6,7 @@ class IosevkaGenerate < Formula
   depends_on :python3
   depends_on "make"
   depends_on "node"
-  depends_on :otfccbuild
+  depends_on "caryll/tap/otfcc-mac64"
   depends_on "ttfautohint"
 
   resource "GitPython" do


### PR DESCRIPTION
I'm new to homebrew and don't know whether it is a good idea to have a direct dependency to another homebrew tap. Nevertheless I created a pull request, just to fix the problem as fast as possible.