### PR TITLE
Fix package dependency

### DIFF
--- a/iosevka-generate.rb
+++ b/iosevka-generate.rb
@@ -3,7 +3,7 @@ class IosevkaGenerate < Formula
   homepage "https://github.com/OJFord/iosevka-generate"
   head "https://github.com/OJFord/iosevka-generate.git", :branch => "master"
 
-  depends_on :python3
+  depends_on :python
   depends_on "make"
   depends_on "node"
   depends_on "caryll/tap/otfcc-mac64"


### PR DESCRIPTION
```
==> Tapping ojford/formulae
Cloning into '/usr/local/Homebrew/Library/Taps/ojford/homebrew-formulae'...
remote: Counting objects: 9, done.
remote: Compressing objects: 100% (9/9), done.
remote: Total 9 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (9/9), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/ojford/homebrew-formulae/iosevka-generate.rb
Calling 'depends_on :python3' is disabled!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/ojford/homebrew-formulae/iosevka-generate.rb:6:in `<class:IosevkaGenerate>'
Please report this to the ojford/formulae tap!
Or, even better, submit a PR to fix it!
```

So here I am.