### PR TITLE
Replace disabled Java dependency format

### DIFF
--- a/ltsa.rb
+++ b/ltsa.rb
@@ -4,7 +4,7 @@ class Ltsa < Formula
   url "http://www.doc.ic.ac.uk/~jnm/book/ltsa/ltsa.jar"
   version "3.0"
   sha256 "2068bfd818f2ea3558ceb78f33ec127a8fc0869c944ee98eacf1ab6d762347de"
-  depends_on :java => "2"
+  depends_on "openjdk@8"
 
   def install
     prefix.install "ltsa.jar"


### PR DESCRIPTION
Homebrew has deprecated and disabled the java dependency format `depends_on :java`
(see Homebrew/brew#9194) resulting in the following error:

```
Error: Failed to import: /usr/local/Homebrew/Library/Taps/ojford/homebrew-formulae/ltsa.rb
ltsa: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead
```

This PR tries to solve the problem by explicitly using "openjdk@8" as dependency, but I haven't tested whether it works yet.
