### PR TITLE
loginitems: fix test block syntax

### DIFF
--- a/loginitems.rb
+++ b/loginitems.rb
@@ -1,7 +1,7 @@
 class Loginitems < Formula
   desc "Tool for managing login items"
   homepage "https://github.com/ojford/loginitems"
-  url "https://github.com/OJFord/loginitems/archive/v1.3.tar.gz"
+  url "https://github.com/OJFord/loginitems/archive/refs/tags/v1.3.tar.gz"
   sha256 "04d8b38c083b3b680c32c7194c8dc1d7bc97435843718e80b15ee57be179bba5"
 
   def install
@@ -12,7 +12,6 @@ class Loginitems < Formula
   end
 
   test do
-    loginitems -h
+    system bin/"loginitems", "-h"
   end
 end
-


### PR DESCRIPTION
Fixes #8

## Description
This PR fixes the syntax error in the test block of loginitems.rb that was causing the "formula is unreadable" warning.

## Changes
- Fixed test block to use proper `system` command syntax
- Changed `loginitems -h` to `system "#{bin}/loginitems", "-h"`

## Testing
- Verified formula can be parsed without warnings
- Confirmed installation still works correctly